### PR TITLE
Backwards compatible approach

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -49,14 +49,20 @@ module OpenTelemetry
           end
 
           def platform_field_key(type, field)
+            return unless config[:enable_platform_field]
+
             "#{type.graphql_name}.#{field.graphql_name}"
           end
 
           def platform_authorized_key(type)
+            return unless config[:enable_platform_authorized]
+
             "#{type.graphql_name}.authorized"
           end
 
           def platform_resolve_type_key(type)
+            return unless config[:enable_platform_resolve_type]
+
             "#{type.graphql_name}.resolve_type"
           end
 
@@ -81,26 +87,24 @@ module OpenTelemetry
             attributes
           end
 
-          def cached_platform_key(ctx, key, trace_phase)
+          def cached_platform_key(ctx, key, trace_phase = nil)
             cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
-
             cache.fetch(key) do
-              cache[key] = begin
-                return unless platform_key_enabled?(ctx, TRACE_PHASE_TO_TYPE.fetch(trace_phase))
-
-                yield
-              end
+              cache[key] = if trace_phase.nil?
+                             # Backwards compatibility for graphql-ruby < 1.13.13 and >= 2 < 2.0.9
+                             # Relates to https://github.com/rmosolgo/graphql-ruby/pull/4077
+                             yield
+                           else
+                             ns = ctx.namespace(:opentelemetry)
+                             if ns.empty?
+                               # Execution context not provided so no request specific config to check
+                               yield
+                             else
+                               config_key = TRACE_PHASE_TO_TYPE.fetch(trace_phase)
+                               yield if ns.fetch(config_key, true)
+                             end
+                           end
             end
-          end
-
-          def platform_key_enabled?(ctx, key)
-            return false unless config[key]
-
-            ns = ctx.namespace(:opentelemetry)
-            return true if ns.empty? # restores original behavior so that keys are returned if tracing is not set in context.
-            return false unless ns.key?(key) && ns[key]
-
-            true
           end
         end
       end


### PR DESCRIPTION
Backwards compatible implementation supports a variety of `graphql-ruby` versions